### PR TITLE
Further performance optimizations

### DIFF
--- a/components/MovieSummary/MovieInfo/TheCastSection/Cast/index.js
+++ b/components/MovieSummary/MovieInfo/TheCastSection/Cast/index.js
@@ -1,7 +1,8 @@
 
 
 import { useState, useRef, useEffect } from 'react';
-import Glider from 'react-glider';
+import dynamic from 'next/dynamic';
+const Glider = dynamic(() => import('react-glider'));
 
 import PersonLink from './PersonLink';
 

--- a/components/MovieSummary/index.js
+++ b/components/MovieSummary/index.js
@@ -2,8 +2,9 @@
 
 import SummaryWrapper from 'parts/SummaryWrapper';
 import MovieArtwork from './MovieArtwork';
-import MovieInfo from './MovieInfo';
 import { W780H1170 } from 'config/image-sizes';
+import dynamic from 'next/dynamic';
+const MovieInfo = dynamic(() => import('./MovieInfo'));
 
 const MovieSummary = ({
   baseUrl,

--- a/components/MyHead/index.js
+++ b/components/MyHead/index.js
@@ -7,7 +7,7 @@ const MyHead = ({ children }) => (
   <Head>
     <link rel='preconnect' href='https://image.tmdb.org' />
     <link rel='preconnect' href='https://api.themoviedb.org' />
-    <link rel='preconnect' href='https://www.google-analytics.com' />
+    {/* <link rel='preconnect' href='https://www.google-analytics.com' /> */}
     <link rel='preconnect' href='https://content-autofill.googleapis.com' />
     <link rel='preload' href={LOGO_IMAGE_PATH} as='image' media='(min-width: 80em)' />
     <link rel='preload' href={DARK_TMDB_IMAGE_PATH} as='image' media='(prefers-color-scheme: dark) and (min-width: 80em)' />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -84,7 +84,7 @@ class MyDocument extends Document {
                 addEventListener('error', window.__e=function f(e){f.q=f.q||[];f.q.push(e)});
               `
             }} />
-          <script async src="https://www.google-analytics.com/analytics.js"></script>
+          {/* <script async src="https://www.google-analytics.com/analytics.js"></script> */}
         </Head>
         <body className={CLASS_NAMES.LIGHT}>
           {/* MEMO: inspired by https://github.com/donavon/use-dark-mode#that-flash */}


### PR DESCRIPTION
* Further use of dynamic import for deferring work we likely don't need immediately, after doing some digging with LH Treemap
* Disabling Google Analytics

WPT comparison of before/after [here](https://www.webpagetest.org/video/compare.php?tests=220903_AiDcHN_8J8,220903_AiDc13_8J9)

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/110953/188285013-cd69acc4-88b9-4264-907d-d711221108c0.png">

This comparison is also sadly not representative because Netlify keep injecting https://netlify-cdp-loader.netlify.app/netlify.js 😢 
